### PR TITLE
fix: #147 breaking bases' filter menu

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,11 +2,6 @@ body {
     --layer-image-toolkit-popup: 1024;
     --layer-image-toolkit-player: 1025;
     --layer-image-toolkit-notice: 1026;
-    --layer-menu: 1027;
-}
-
-.menu {
-    z-index: var(--layer-menu);
 }
 
 .notice-container {


### PR DESCRIPTION
issue #146 

The `.menu` class messes up the bases' menues. Since I was not able to find any `image toolkit` view where `document.querySelectorAll('.menu')` returned any results I thought the easiest way is to get rid of it.

I also could not find any place in the codebase where it is used.

If the `.menu` class is planned to be used later, just give it a less generic name.
